### PR TITLE
CommonJS support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,6 @@
   ],
   "license": "AP2",
   "dependencies": {
-    "lodash": "~2.4.1",
     "pixi.js": "~2.1.1"
   }
 }

--- a/examples/cupcake/cupcake.html
+++ b/examples/cupcake/cupcake.html
@@ -17,7 +17,7 @@
             border : 0;
         }
     </style>
-    <script src="../../bower_components/pixi.js/bin/pixi.dev.js"></script>
+    <script src="../../node_modules/pixi.js/bin/pixi.dev.js"></script>
     <script src="../../build/react-pixi.js"></script>
     <script src="cupcake.js"></script>
 </head>

--- a/examples/interactive/interactive.html
+++ b/examples/interactive/interactive.html
@@ -17,8 +17,8 @@
             border : 0;
         }
     </style>
-    <script src="../../bower_components/lodash/dist/lodash.min.js"></script>
-    <script src="../../bower_components/pixi.js/bin/pixi.dev.js"></script>
+    <script src="../../node_modules/lodash/index.js"></script>
+    <script src="../../node_modules/pixi.js/bin/pixi.dev.js"></script>
     <script src="../../build/react-pixi.js"></script>
     <script src="interactive.js"></script>
 </head>

--- a/examples/jsxtransform/jsxtransform.html
+++ b/examples/jsxtransform/jsxtransform.html
@@ -17,7 +17,7 @@
             border : 0;
         }
     </style>
-    <script src="../../bower_components/pixi.js/bin/pixi.dev.js"></script>
+    <script src="../../node_modules/pixi.js/bin/pixi.dev.js"></script>
     <script src="../../build/react-pixi.js"></script>
 
     <!-- run 'gulp jsxexample' to compile the .jsx file to .js -->

--- a/examples/subclasssprite/spinningsprite.html
+++ b/examples/subclasssprite/spinningsprite.html
@@ -17,7 +17,7 @@
             border : 0;
         }
     </style>
-    <script src="../../vendor/pixi.dev.js"></script>
+    <script src="../../node_modules/pixi.js/bin/pixi.dev.js"></script>
     <script src="../../build/react-pixi.js"></script>
     <script src="spinningsprite.js"></script>
 </head>

--- a/examples/viewpixeltests/viewpixeltests.html
+++ b/examples/viewpixeltests/viewpixeltests.html
@@ -17,8 +17,8 @@
             border : 0;
         }
     </style>
-    <script src="../../bower_components/lodash/dist/lodash.min.js"></script>
-    <script src="../../bower_components/pixi.js/bin/pixi.dev.js"></script>
+    <script src="../../node_modules/lodash/index.js"></script>
+    <script src="../../node_modules/pixi.js/bin/pixi.dev.js"></script>
     <script src="../../build/react-pixi.js"></script>
     <script src="../../test/pixels/pixelTests.js"></script>
     <script src="viewpixeltests.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ var jsxtransform = require('gulp-react');
 
 var karma = require('karma');
 var browserify = require('browserify');
+var browserifyShim = require('browserify-shim');
 var pkg = require('./package.json');
 
 //
@@ -54,8 +55,8 @@ var banner = ['/**',
 var browserlist = ['Firefox'];
 var karmaconfiguration = {
     browsers: browserlist,
-    files: ['bower_components/lodash/dist/lodash.min.js',
-            'bower_components/pixi.js/bin/pixi.dev.js',
+    files: [require.resolve('lodash'),
+            require.resolve('pixi.js'),
             'build/react-pixi.js',
             'vendor/phantomjs-shims.js', // need a shim to work with the ancient version of Webkit used in PhantomJS
             'node_modules/resemblejs/resemble.js',
@@ -95,6 +96,7 @@ gulp.task('browserify',['lint'], function() {
   var bundler = browserify();
   bundler.require('react');
   bundler.require('./src/ReactPIXI.js',{expose:'react-pixi'});
+  bundler.transform(browserifyShim);
 
   // If we're running a gulp.watch and browserify finds an error, it will
   // throw an exception and terminate gulp unless we catch the error event.

--- a/package.json
+++ b/package.json
@@ -17,13 +17,14 @@
     "url": "https://github.com/Izzimach/react-pixi"
   },
   "license": "Apache-2.0",
-  "main": "build/react-pixi.js",
+  "main": "src/ReactPIXI.js",
   "peerDependencies": {
+    "pixi.js": "^2.2.7",
     "react": "^0.12.2"
   },
   "devDependencies": {
-    "react": "^0.12.2",
     "browserify": "~7.0.0",
+    "browserify-shim": "^3.8.3",
     "envify": "^3.2.0",
     "gulp": "~3.8.10",
     "gulp-concat": "~2.4.0",
@@ -37,7 +38,9 @@
     "karma": "~0.12.23",
     "karma-firefox-launcher": "~0.1.3",
     "karma-jasmine": "~0.3.2",
+    "lodash": "^3.3.1",
     "node-static": "~0.7.3",
+    "react": "^0.12.2",
     "react-tools": "^0.12.2",
     "resemblejs": "~1.2.0",
     "rimraf": "~2.2.8",
@@ -49,5 +52,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "browserify-shim": {
+    "pixi.js": "global:PIXI"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "karma-jasmine": "~0.3.2",
     "lodash": "^3.3.1",
     "node-static": "~0.7.3",
+    "pixi.js": "^2.2.7",
     "react": "^0.12.2",
     "react-tools": "^0.12.2",
     "resemblejs": "~1.2.0",

--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -41,6 +41,8 @@ var shouldUpdateReactComponent = require('react/lib/shouldUpdateReactComponent')
 var instantiateReactComponent = require ('react/lib/instantiateReactComponent');
 var invariant = require('react/lib/invariant');
 
+var PIXI = require('pixi.js');
+
 //
 // Generates a React component by combining several mixin components
 //


### PR DESCRIPTION
This pull request make react-pixi compatible with CommonJS.

```javascript
var React = require('react');
var ReactPIXI = require('react-pixi');
var PIXI = require('pixi.js');
```

We can bundle code by using Browserify, and also we can install by using Bower.