### PR TITLE
Fix require capitalisation

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -32,7 +32,7 @@ var ReactMultiChild = require('react/lib/ReactMultiChild');
 var ReactBrowserComponentMixin = require('react/lib/ReactBrowserComponentMixin');
 var ReactDOMComponent = require('react/lib/ReactDOMComponent');
 var ReactComponentMixin = ReactComponent.Mixin;
-var ReactCompositeComponent = require('react/lib/ReactCompositecomponent');
+var ReactCompositeComponent = require('react/lib/ReactCompositeComponent');
 
 var assign = require('react/lib/Object.assign');
 var emptyObject = require('react/lib/emptyObject');


### PR DESCRIPTION
I was having issues with browserify working locally (on OSX) but not when deploying to heroku (Ubuntu).

The error:

```
remote:        > browserify -t reactify js/client_main.js > public/js/bundle.js
remote:
remote:        Error: Cannot find module 'react/lib/ReactCompositecomponent' from '/tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/react-pixi/src'
remote:            at /tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
remote:            at process (/tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
remote:            at ondir (/tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
remote:            at load (/tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
remote:            at onex (/tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
remote:            at /tmp/build_5b8dd298dabe6f7fdb507087320de3ac/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
remote:            at FSReqWrap.oncomplete (fs.js:95:15)
```

`ReactCompositecomponent` seemed suspicious and sure enough forking and capitalising to `ReactCompositeComponent` fixed my problem. I'm confident this must be down to OSX's case-insensitive file-system.