### PR TITLE
Adjusting where the main file points to

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "es5",
     "src"
   ],
-  "main": "es5/ReactPIXI.js",
+  "main": "es5/react-pixi-commonjs.js",
   "dependencies": {
     "fbjs": "^0.2.1"
   },


### PR DESCRIPTION
After testing locally this change to package.json resolves my problem regarding not being able to find the react-pixi module in my ES6 code.

This should resolve https://github.com/Izzimach/react-pixi/issues/24