### PR TITLE
adds a boilerplate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ var PIXI = require('pixi.js');
 
 It turns out that [PIXI dumps itself into the global namespace](https://github.com/pixijs/pixi.js/blob/master/src/index.js#L27) so you don't have to require it if you don't want to.
 
+To use react-pixi with webpack, babel, and hot reloading, you can use [this boilerplate][rpb].
+
+[rpb]: https://github.com/brigand/react-pixi-boilerplate
+
 ## Building From Source
 
 You will need node and npm.


### PR DESCRIPTION
The examples are written a little strangely so I think having a boilerplate will help people pick up react-pixi and build things. I won't be offended if you say no to this, though :smile: 