### PR TITLE
Add transparent option to PIXIStage

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -308,6 +308,7 @@ var PIXIStage = React.createClass({
       {view:renderelement,
        backgroundColor: backgroundcolor, 
        antialias: props.antialias,
+       transparent: transparent,
        resolution: props.resolution	
       });
   },


### PR DESCRIPTION
i found that the `transparent` option of `PIXIStage` is missing... 👀 