### PR TITLE
feat: add Graphics as an import

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -480,6 +480,27 @@ var DisplayObjectContainer = createPIXIComponent(
 });
 
 //
+// Graphics
+//
+
+var Graphics = createPIXIComponent(
+  'Graphics',
+  DisplayObjectContainerMixin,
+  CommonDisplayObjectContainerImplementation, {
+
+  createDisplayObject : function() {
+  	return new PIXI.Graphics();
+  },
+
+  applySpecificDisplayObjectProps: function (oldProps, newProps) {
+    this.transferDisplayObjectPropsByName(oldProps, newProps, {
+      'width': undefined,
+      'height': undefined
+    });
+  }
+});
+
+//
 // Sprite
 //
 
@@ -742,7 +763,8 @@ var PIXIComponents = {
   Sprite : Sprite,
   Text : Text,
   BitmapText : BitmapText,
-  TilingSprite : TilingSprite
+  TilingSprite : TilingSprite,
+  Graphics : Graphics
 };
 
 var PIXIFactories = {};


### PR DESCRIPTION
Example Usage
```JS
import React, { Component } from 'react';
import {Graphics} from 'react-pixi';

export default class GraphicsExample extends Component {
  componentDidMount() {
    const graphics = this.refs.graphics;
    graphics.beginFill(0x3498db);
    graphics.drawEllipse(170, 185, 45, 25);
    graphics.endFill();
  }
  render() {
    return (
      <Graphics ref='graphics' />
    );
  }
}
```