### PR TITLE
Fixed pixi.js import

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -25,7 +25,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PIXI from 'pixi.js';
+import * from PIXI from 'pixi.js';
 
 import ReactMultiChild from 'react-dom/lib/ReactMultiChild';
 import ReactElement from 'react/lib/ReactElement';


### PR DESCRIPTION
Based on https://github.com/pixijs/pixi.js/issues/3204, since there are no default export in PIXI, the correct way to import the library is by using `import * as PIXI from 'pixi.js';`