### PR TITLE
Add typescript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pixi",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Construct PIXI.js scenes using React",
   "keywords": [
     "react",
@@ -32,8 +32,8 @@
   },
   "peerDependencies": {
     "pixi.js": "~4.0.0",
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0"
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
@@ -54,8 +54,8 @@
     "lodash": "^4.6.1",
     "node-static": "~0.7.3",
     "pixi.js": "~4.0.0",
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "resemblejs": "~2.2.0",
     "rimraf": "~2.5.0",
     "transform-loader": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "es5",
     "src"
   ],
+  "types": "react-pixi.d.ts",
   "main": "es5/react-pixi-commonjs.js",
   "dependencies": {
     "brfs": "^1.4.1",

--- a/react-pixi.d.ts
+++ b/react-pixi.d.ts
@@ -1,0 +1,53 @@
+declare module 'react-pixi' {
+  import {
+    Component,
+    ComponentClass,
+    CSSProperties,
+    SFC,
+    ComponentFactory,
+    ClassType,
+  } from 'react';
+  import * as React from 'react';
+  import { render, unmountComponentAtNode } from 'react-dom';
+  import {
+    Point,
+  } from 'pixi.js';
+
+  export type StagePropsType = {
+    width: number, height: number,
+    style?: CSSProperties, backgroundColor?: number,
+    transparent?: boolean,
+  };
+  export class Stage extends Component<StagePropsType, void> {}
+
+  export type TilingSpritePropsType = {
+    image: string, width: number, height: number,
+  };
+  export class TilingSprite extends Component<TilingSpritePropsType, void> {}
+
+  export type TextPropsType = {
+    text: string,
+    x: number, y: number,
+    style: CSSProperties,
+    anchor: Point,
+  };
+  export class Text extends Component<TextPropsType, void> {}
+
+  export type DisplayObjectContainerPropsType = {
+    x: number, y: number,
+  }
+  export const DisplayObjectContainer: SFC<DisplayObjectContainerPropsType>;
+  export class CustomPixiComponentClass<CustomProps, PixiComponent>
+      extends React.Component<CustomProps, void> {
+    displayObject: PixiComponent;
+  }
+  export interface CustomPixiComponentClassFactory<CustomProps, PixiComponent>
+    extends ComponentFactory<CustomProps, CustomPixiComponentClass<CustomProps, PixiComponent>> {
+  }
+  export function CustomPIXIComponent<CustomProps, PixiComponent>(args: {
+    customDisplayObject(props: CustomProps): PixiComponent,
+    customDidAttach?(displayObject: PixiComponent): void,
+    customApplyProps(displayObject: PixiComponent, oldProps: CustomProps, newProps: CustomProps): void,
+    customWillDetach?(displayObject: PixiComponent): void,
+  }): CustomPixiComponentClassFactory<CustomProps, PixiComponent>
+}

--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -25,7 +25,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import * from PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js';
 
 import ReactMultiChild from 'react-dom/lib/ReactMultiChild';
 import ReactElement from 'react/lib/ReactElement';

--- a/webpack-commonjs.config.js
+++ b/webpack-commonjs.config.js
@@ -12,7 +12,9 @@ _.assign(commonjsconfig, {
   externals: [
     "pixi.js",
     "react",
-    /^react\/lib\/.+/  // any require that refers to internal react modules
+    "react-dom",
+    /^react\/lib\/.+/,  // any require that refers to internal react modules
+    /^react-dom\/lib\/.+/  // any require that refers to internal react modules
   ]
 });
 _.assign(commonjsconfig.output, {


### PR DESCRIPTION
Note: users should be careful not to do:
```typescript
import {
   Stage, TilingSprite,
} from 'react-pixi'
```

as react-pixi doesn't seem to support (in es6 form)
```
import {
   Stage, TilingSprite,
} from 'react-pixi';
```
- Most libraries that do not support es6-import have definition files that warn about es6-import usage, but I couldn't pull that off for this one :(