### PR TITLE
Use ParticleContainer instead of SpriteBatch

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -624,17 +624,17 @@ var Sprite = createPIXIComponent(
   SpriteComponentMixin );
 
 //
-// SpriteBatch
+// ParticleContainer
 //
 
 
-var SpriteBatch = createPIXIComponent(
-  'SpriteBatch',
+var ParticleContainer = createPIXIComponent(
+  'ParticleContainer',
   DisplayObjectContainerMixin,
   CommonDisplayObjectContainerImplementation, {
 
   createDisplayObject : function() {
-    return new PIXI.SpriteBatch();
+    return new PIXI.particles.ParticleContainer();
   },
 
   applySpecificDisplayObjectProps: function (oldProps, newProps) {
@@ -830,7 +830,7 @@ var CustomPIXIComponent = function (custommixin) {
 var PIXIComponents = {
   Stage : PIXIStage,
   DisplayObjectContainer : DisplayObjectContainer,
-  SpriteBatch : SpriteBatch,
+  ParticleContainer : ParticleContainer,
   Sprite : Sprite,
   Text : Text,
   BitmapText : BitmapText,

--- a/test/basics/tests.js
+++ b/test/basics/tests.js
@@ -16,7 +16,7 @@ describe("React and React.PIXI modules", function() {
     expect(React.DOM).toBeDefined();
     expect(ReactPIXI.Stage).toBeDefined();
     expect(ReactPIXI.DisplayObjectContainer).toBeDefined();
-    expect(ReactPIXI.SpriteBatch).toBeDefined();
+    expect(ReactPIXI.ParticleContainer).toBeDefined();
     expect(ReactPIXI.Text).toBeDefined();
     expect(ReactPIXI.Sprite).toBeDefined();
     expect(ReactPIXI.BitmapText).toBeDefined();


### PR DESCRIPTION
`PIXI.SpriteBatch` is deprecated since `pixi.js@3.0.0` and `PIXI.ParticleContainer` is deprecated in favour of `PIXI.particles.ParticleContainer` since `pixi.js@4.0.0`. Current version of `react-pixi` depends on at least `4.0.0` hence this pull request.

I would not consider it a breaking change, because you can't use SpriteBatch since `3.0.0` anyway.

Fixes #74 