### PR TITLE
Update BitmapText after style prop is changed

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -743,6 +743,12 @@ var BitmapTextComponentMixin = {
     // should do a deep compare here
     if (typeof newProps.style !== 'undefined' && newProps.style !== oldProps.style) {
       displayObject.style = newProps.style;
+      if (typeof oldProps.style === 'undefined' || newProps.style.font !== oldProps.style.font) {
+        let font = newProps.style.font.split(' ')
+        displayObject.font.name = font[1]
+        displayObject.font.size = parseInt(font[0], 10)
+        displayObject.updateText()
+      }
     }
 
     this.transferDisplayObjectPropsByName(oldProps, newProps,


### PR DESCRIPTION
Currently if you change style prop on ReactPIXI.BitmapText, the change in font face or size is not reflected.