### PR TITLE
Setting Point-like props using objects, arrays and strings

### DIFF
--- a/examples/pointlikeprops/pointlikeprops.html
+++ b/examples/pointlikeprops/pointlikeprops.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+
+    <title>React-pixi test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #000000;
+        }
+        #pixi-box canvas {
+            display: block;
+            margin: auto;
+            padding: 0;
+            border : 0;
+        }
+    </style>
+    <script src="../../build/react-pixi.js"></script>
+    <script src="pointlikeprops.js"></script>
+</head>
+<body>
+    <div id="pixi-box"></div>
+    <script>
+    window.onload = pointlikepropsstart;
+    </script>
+ </body>
+</html>

--- a/examples/pointlikeprops/pointlikeprops.js
+++ b/examples/pointlikeprops/pointlikeprops.js
@@ -1,0 +1,144 @@
+//
+// Basic React-PIXI example using a custom 'Cupcake' Component which consists of two sprites
+//
+
+/* jshint strict: false */
+/* global React : false */
+/* global ReactPIXI : false */
+/* global PIXI : false */
+
+var assetpath = function(filename) { return '../assets/' + filename; };
+
+var Stage = React.createFactory(ReactPIXI.Stage);
+var Sprite = React.createFactory(ReactPIXI.Sprite);
+var DisplayObjectContainer = React.createFactory(ReactPIXI.DisplayObjectContainer);
+var TilingSprite = React.createFactory(ReactPIXI.TilingSprite);
+var VectorText = React.createFactory(ReactPIXI.Text);
+var BitmapText = React.createFactory(ReactPIXI.BitmapText);
+
+//
+// Here's a cupcake component that gloms together two sprites to render a cupcake
+//
+// props:
+// - xposition : center x axis of the cupcake
+// - cream : type of cupcake topping. any of the keys listed in spritemapping
+//
+
+var CupcakeComponent = React.createClass({
+  displayName: 'CupcakeComponent',
+  // maps from cupcake toppings to the appropriate sprite
+  spritemapping : {
+  'vanilla' : assetpath('creamVanilla.png'),
+  'chocolate' : assetpath('creamChoco.png'),
+  'mocha' : assetpath('creamMocha.png'),
+  'pink' : assetpath('creamPink.png'),
+  },
+
+  propTypes: {
+    xposition: React.PropTypes.number.isRequired,
+    topping: React.PropTypes.string.isRequired,
+    scale: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+      React.PropTypes.instanceOf(PIXI.Point),
+      React.PropTypes.instanceOf(PIXI.ObservablePoint),
+      React.PropTypes.arrayOf(React.PropTypes.number),
+      React.PropTypes.objectOf(React.PropTypes.number)
+    ]),
+    skew: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+      React.PropTypes.instanceOf(PIXI.Point),
+      React.PropTypes.instanceOf(PIXI.ObservablePoint),
+      React.PropTypes.arrayOf(React.PropTypes.number),
+      React.PropTypes.objectOf(React.PropTypes.number)
+    ]),
+  },
+
+  defaultProps: {
+    scale: new PIXI.Point(1, 1),
+    skew: new PIXI.Point(0, 0)
+  },
+
+  render : function () {
+    var creamimagename = this.spritemapping[this.props.topping];
+    var xposition = this.props.xposition;
+    var scale = this.props.scale;
+    var skew = this.props.skew;
+    return DisplayObjectContainer(
+      {x:xposition, y:100, scale: scale, skew: skew },
+      Sprite({image:creamimagename, y:-35, anchor: new PIXI.Point(0.5,0.5), key:'topping'}, null),
+      Sprite({image:assetpath('cupCake.png'), y:35, anchor: new PIXI.Point(0.5,0.5), key:'cake'}, null)
+    );
+  }
+});
+var CupcakeFactory = React.createFactory(CupcakeComponent);
+
+//
+// The top level component
+// props:
+// - width,height : size of the overall render canvas in pixels
+// - xposition: x position in pixels that governs where the elements are placed
+//
+
+var ExampleStage = React.createClass({
+  displayName: 'ExampleStage',
+  getInitialState: function() {
+    return {backgroundX: 0, backgroundY: 0, scrollcallback:null};
+  },
+  componentDidMount: function() {
+    var componentinstance = this;
+    var animationcallback = function() {
+      var newstate = {
+        backgroundX: componentinstance.state.backgroundX - 1,
+        backgroundY: componentinstance.state.backgroundY - 2,
+        scrollcallback: requestAnimationFrame(animationcallback)
+      };
+
+      componentinstance.setState(newstate);
+    }.bind(this);
+
+    componentinstance.setState({scrollcallback: requestAnimationFrame(animationcallback)});
+  },
+  componentWillUnmount: function() {
+    if (this.state.scrollcallback !== null) {
+      cancelAnimationFrame(this.state.scrollcallback);
+    }
+  },
+  render: function() {
+    return Stage(
+      {width:this.props.width, height:this.props.height},
+      // setting tilePosition by array of [x,y] and tileScale by PIXI.ObservablePoint instance
+      TilingSprite({image:assetpath('bg_castle.png'), width:this.props.width, height:this.props.height, tilePosition: [this.state.backgroundX, this.state.backgroundY], tileScale: new PIXI.ObservablePoint(function() {}, {}, 0.5, 0.75), key:1}, null),
+      // setting position by x and y properties
+      CupcakeFactory({topping:this.props.topping, xposition:this.props.xposition, ref:'cupcake', key:2}),
+      // setting anchor by string of "x,y"
+      VectorText({text:'Vector text', x:this.props.xposition, y:10, style:{font:'40px Times'}, anchor: "0.5,0", key:3}, null),
+      // setting pivot by PIXI.Point instance
+      BitmapText({text:'Bitmap text', pivot: new PIXI.Point(-this.props.xposition, -180), tint:0xff88ff88, style: {font:'40 Comic_Neue_Angular'}, key:4}, null),
+      // setting scale by single number
+      CupcakeFactory({topping:'pink', xposition:320, scale: 0.5, ref:'pinkcupcake', key:5}),
+      // setting skew by string of single number
+      CupcakeFactory({topping:'mocha', xposition:80, skew: "-0.25", ref:'mochacupcake', key:6}),
+    );
+  }
+});
+
+/* jshint unused:false */
+function pointlikepropsstart() {
+    var renderelement = document.getElementById("pixi-box");
+
+    var w = window.innerWidth-6;
+    var h = window.innerHeight-6;
+
+    function PutReact()
+    {
+      var stageElement = React.createElement(ExampleStage, {width:w, height:h, xposition:200, topping:'vanilla'});
+      ReactPIXI.render(stageElement, renderelement);
+    }
+
+    var fontloader = PIXI.loader;
+    fontloader.add('comic_neue_angular_bold', assetpath('comic_neue_angular_bold.fnt'));
+    fontloader.on('complete', PutReact);
+    fontloader.load();
+}

--- a/examples/pointlikeprops/pointlikeprops.js
+++ b/examples/pointlikeprops/pointlikeprops.js
@@ -55,9 +55,11 @@ var CupcakeComponent = React.createClass({
     ]),
   },
 
-  defaultProps: {
-    scale: new PIXI.Point(1, 1),
-    skew: new PIXI.Point(0, 0)
+  getDefaultProps: function() {
+    return {
+      scale: new PIXI.Point(1, 1),
+      skew: new PIXI.Point(0, 0)
+    }
   },
 
   render : function () {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   <body>
     <h1>Examples</h1>
     <p><a href="examples/cupcake/cupcake.html">A cupcake</a></p>
+    <p><a href="examples/pointlikeprops/pointlikeprops.html">Setting Point-like props</a></p>
     <p><a href="examples/interactive/interactive.html">Interactive</a></p>
     <p><a href="examples/filters/filters.html">Filter demo</a></p>
     <p><a href="examples/customrender/customrender.html">Custom Renderer</a></p>

--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -141,7 +141,6 @@ function setPixiValue(container, key, value) {
 //
 // A DisplayObject has some standard properties and default values
 //
-
 var gStandardProps = {
   alpha:1,
   buttonMode:false,
@@ -165,6 +164,19 @@ var gStandardProps = {
   // x has special behavior
   // y has special behavior
 };
+
+//
+// A DisplayObject Point-like props
+//
+var gPointLikeProps = [
+  'anchor',
+  'pivot',
+  'position',
+  'scale',
+  'skew',
+  'tilePosition',
+  'tileScale'
+]
 
 var gPIXIHandlers = [
   'click',
@@ -208,6 +220,13 @@ var DisplayObjectMixin = {
         setPixiValue(displayObject, propname, propsToCheck[propname]);
       }
     }
+
+    // parse Point-like prop values
+    gPointLikeProps.forEach(function(propname) {
+      if (typeof newProps[propname] !== 'undefined') {
+        setPixiValue(displayObject, propname, newProps[propname]);
+      }
+    })
   },
 
   applyDisplayObjectProps(oldProps, newProps) {
@@ -217,9 +236,7 @@ var DisplayObjectMixin = {
 
     // Position can be specified using either 'position' or separate
     // x/y fields. If neither of these is specified we set them to 0
-    if (typeof newProps.position !== 'undefined') {
-      displayObject.position = newProps.position;
-    } else {
+    if (typeof newProps.position === 'undefined') {
       if (typeof newProps.x !== 'undefined') {
         displayObject.x = newProps.x;
       } else {

--- a/test/components/displayobjectcontainer.js
+++ b/test/components/displayobjectcontainer.js
@@ -152,4 +152,132 @@ describe("PIXI DisplayObject Component", function() {
     //This should be a ReactPIXI stage.
     expect(reactinstance.refs.stage.renderStage).toBeDefined();
   });
+
+  var Stage = React.createFactory(ReactPIXI.Stage);
+  var DisplayObjectContainer = React.createFactory(ReactPIXI.DisplayObjectContainer);
+
+  var DisplayObjectContainerTestComponent = React.createClass({
+    displayName: 'ExampleTilingSpriteComponent',
+    render: function () {
+      return Stage({width: 800, height: 600, ref: 'stage'},
+        DisplayObjectContainer(this.props));
+     }
+  });
+
+  var DisplayObjectContainerTest = React.createFactory(DisplayObjectContainerTestComponent);
+
+  it('The position property can be updated by x and y props', (done) => {
+    var setAndExpect = [
+      {x: -420, y: -420, expect: new PIXI.Point(-420, -420)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        DisplayObjectContainerTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          x: data.x,
+          y: data.y
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var displayObject = stage.children[0];
+      expect(displayObject.x).toBe(data.expect.x);
+      expect(displayObject.y).toBe(data.expect.y);
+      expect(displayObject.position.x).toBe(data.expect.x);
+      expect(displayObject.position.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
+
+  it('The position property can be updated by position prop in all the various forms', (done) => {
+    var setAndExpect = [
+      {set: [-420], expect: new PIXI.Point(-420, -420)},
+      {set: [169, 532], expect: new PIXI.Point(169, 532)},
+      {set: "4", expect: new PIXI.Point(4, 4)},
+      {set: "42,68", expect: new PIXI.Point(42, 68)},
+      {set: new PIXI.Point(123, 456), expect: new PIXI.Point(123, 456)},
+      {set: new PIXI.Point(123), expect: new PIXI.Point(123, 0)},
+      {set: new PIXI.ObservablePoint(() => {}, {}, 654, 321), expect: new PIXI.Point(654, 321)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        DisplayObjectContainerTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          position: data.set
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var displayObject = stage.children[0];
+      expect(displayObject.x).toBe(data.expect.x);
+      expect(displayObject.y).toBe(data.expect.y);
+      expect(displayObject.position.x).toBe(data.expect.x);
+      expect(displayObject.position.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
+
+  it('The pivot property can be updated by position prop in all the various forms', (done) => {
+    var setAndExpect = [
+      {set: [-420], expect: new PIXI.Point(-420, -420)},
+      {set: [169, 532], expect: new PIXI.Point(169, 532)},
+      {set: "4", expect: new PIXI.Point(4, 4)},
+      {set: "42,68", expect: new PIXI.Point(42, 68)},
+      {set: new PIXI.Point(123, 456), expect: new PIXI.Point(123, 456)},
+      {set: new PIXI.Point(123), expect: new PIXI.Point(123, 0)},
+      {set: new PIXI.ObservablePoint(() => {}, {}, 654, 321), expect: new PIXI.Point(654, 321)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        DisplayObjectContainerTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          pivot: data.set
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var displayObject = stage.children[0];
+      expect(displayObject.pivot.x).toBe(data.expect.x);
+      expect(displayObject.pivot.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
+
+  it('The scale property can be updated by position prop in all the various forms', (done) => {
+    var setAndExpect = [
+      {set: [-1], expect: new PIXI.Point(-1, -1)},
+      {set: [0.5, 1], expect: new PIXI.Point(0.5, 1)},
+      {set: "0.25", expect: new PIXI.Point(0.25, 0.25)},
+      {set: "1,1", expect: new PIXI.Point(1, 1)},
+      {set: new PIXI.Point(1, 0.5), expect: new PIXI.Point(1, 0.5)},
+      {set: new PIXI.Point(-0.5), expect: new PIXI.Point(-0.5, 0)},
+      {set: new PIXI.ObservablePoint(() => {}, {}, 0.5, -1), expect: new PIXI.Point(0.5, -1)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        DisplayObjectContainerTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          scale: data.set
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var displayObject = stage.children[0];
+      expect(displayObject.scale.x).toBe(data.expect.x);
+      expect(displayObject.scale.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
 });

--- a/test/components/sprite.js
+++ b/test/components/sprite.js
@@ -51,4 +51,77 @@ describe("PIXI Sprite Component", function() {
 
     });
   });
+
+  var Stage = React.createFactory(ReactPIXI.Stage);
+  var Sprite = React.createFactory(ReactPIXI.Sprite);
+
+  var SpriteTestComponent = React.createClass({
+    displayName: 'ExampleSpriteComponent',
+    render: function () {
+      return Stage({width: 800, height: 600, ref: 'stage'},
+        Sprite(this.props));
+     }
+  });
+
+  var SpriteTest = React.createFactory(SpriteTestComponent);
+
+  it('The anchor property can be updated by position prop in all the various forms', (done) => {
+    var setAndExpect = [
+      {set: [-1], expect: new PIXI.Point(-1, -1)},
+      {set: [0.5, 1], expect: new PIXI.Point(0.5, 1)},
+      {set: "0.25", expect: new PIXI.Point(0.25, 0.25)},
+      {set: "1,1", expect: new PIXI.Point(1, 1)},
+      {set: new PIXI.Point(1, 0.5), expect: new PIXI.Point(1, 0.5)},
+      {set: new PIXI.Point(-0.5), expect: new PIXI.Point(-0.5, 0)},
+      {set: new PIXI.ObservablePoint(() => {}, {}, 0.5, -1), expect: new PIXI.Point(0.5, -1)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        SpriteTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          anchor: data.set,
+          texture: PIXI.Texture.EMPTY
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var sprite = stage.children[0];
+      expect(sprite.anchor.x).toBe(data.expect.x);
+      expect(sprite.anchor.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
+
+  it('The anhor property can be updated by position prop in all the various forms', (done) => {
+    var setAndExpect = [
+      {set: [-1], expect: new PIXI.Point(-1, -1)},
+      {set: [0.5, 1], expect: new PIXI.Point(0.5, 1)},
+      {set: "0.25", expect: new PIXI.Point(0.25, 0.25)},
+      {set: "1,1", expect: new PIXI.Point(1, 1)},
+      {set: new PIXI.Point(1, 0.5), expect: new PIXI.Point(1, 0.5)},
+      {set: new PIXI.Point(-0.5), expect: new PIXI.Point(-0.5, 0)},
+      {set: new PIXI.ObservablePoint(() => {}, {}, 0.5, -1), expect: new PIXI.Point(0.5, -1)}
+    ];
+
+    setAndExpect.forEach( (data) => {
+      var reactInstance = ReactPIXI.render(
+        SpriteTest({
+          // TODO: also set the other tiling transforms (for testing observable points)
+          skew: data.set,
+          texture: PIXI.Texture.EMPTY
+        }),
+        mountpoint
+      );
+
+      var stage = reactInstance.refs['stage']._displayObject;
+      var sprite = stage.children[0];
+      expect(sprite.skew.x).toBe(data.expect.x);
+      expect(sprite.skew.y).toBe(data.expect.y);
+    });
+
+    done();
+  });
 });


### PR DESCRIPTION
This was first requested in #58 and almost fixed in #61. However, it never worked for properties other than `tilePosition` and `tileScale` on `TilingSprite`.

I have added a list of Point-like props (`gPointLikeProps`) that should now work like the above. Existing and new unit tests cover all props and use cases.