### PR TITLE
Replace React.createClass calls with createReactClass (since React 15.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Then browse to `http://localhost:8080`
 To render Pixi.js elements like a Stage or Sprite you reference them like other
 components that were created with `React.createClass`.  For React 0.12 and later,
 this means you have to use `React.createElement` or create factories from the
-basic ReactPIXI components. For example, to construct
+basic ReactPIXI components. From React 15.5, instead of using `React.createClass` you should use `createReactClass` from a separate `create-react-class` package. For example, to construct
  a CupcakeComponent that consists of two Sprites:
 
 ```js

--- a/examples/cupcake/cupcake.js
+++ b/examples/cupcake/cupcake.js
@@ -6,6 +6,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 
 var assetpath = function(filename) { return '../assets/' + filename; };
 
@@ -24,7 +25,7 @@ var BitmapText = React.createFactory(ReactPIXI.BitmapText);
 // - cream : type of cupcake topping. any of the keys listed in spritemapping
 //
 
-var CupcakeComponent = React.createClass({
+var CupcakeComponent = createReactClass({
   displayName: 'CupcakeComponent',
   // maps from cupcake toppings to the appropriate sprite
   spritemapping : {
@@ -58,7 +59,7 @@ var CupcakeFactory = React.createFactory(CupcakeComponent);
 // - xposition: x position in pixels that governs where the elements are placed
 //
 
-var ExampleStage = React.createClass({
+var ExampleStage = createReactClass({
   displayName: 'ExampleStage',
   getInitialState: function() {
     return {backgroundX: 0, backgroundY: 0, scrollcallback:null};

--- a/examples/customrender/customrender.js
+++ b/examples/customrender/customrender.js
@@ -6,13 +6,14 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 
 var assetpath = function(filename) { return '../assets/' + filename; };
 
 var Stage = React.createFactory(ReactPIXI.Stage);
 var VectorText = React.createFactory(ReactPIXI.Text);
 
-var CustomRenderStage = React.createClass({
+var CustomRenderStage = createReactClass({
   displayName: 'CustomRenderStage',
   render: function() {
     return Stage(

--- a/examples/filters/filters.js
+++ b/examples/filters/filters.js
@@ -6,6 +6,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 
 var assetpath = function(filename) { return '../assets/' + filename; };
 
@@ -24,7 +25,7 @@ var BitmapText = React.createFactory(ReactPIXI.BitmapText);
 // - cream : type of cupcake topping. any of the keys listed in spritemapping
 //
 
-var CupcakeComponent = React.createClass({
+var CupcakeComponent = createReactClass({
   displayName: 'CupcakeComponent',
   // maps from cupcake toppings to the appropriate sprite
   spritemapping : {
@@ -60,7 +61,7 @@ var CupcakeFactory = React.createFactory(CupcakeComponent);
 // - bluramount: 0=no blur, 2=a bit fuzzy, 10+ is mostly obscured
 //
 
-var BlurredCupcakeComponent = React.createClass({
+var BlurredCupcakeComponent = createReactClass({
   displayName: "BlurredCupcakeComponent",
   getInitialState : function() {
     return { cupcakefilter : new PIXI.filters.BlurFilter() };
@@ -96,7 +97,7 @@ var BlurredCupcakeFactory = React.createFactory(BlurredCupcakeComponent);
 // - xposition: x position in pixels that governs where the elements are placed
 //
 
-var ExampleStage = React.createClass({
+var ExampleStage = createReactClass({
   displayName: 'ExampleStage',
   render: function() {
     // draw two cupcakes each at different positions

--- a/examples/interactive/interactive.js
+++ b/examples/interactive/interactive.js
@@ -11,6 +11,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 /* jshint strict: false */
 
 var Stage = React.createFactory(ReactPIXI.Stage);
@@ -88,7 +89,7 @@ function removeSpriteById(spriteid) {
 // Component to hold a clickable sprite 'button'. click on this 'button' to add a sprite
 //
 
-var SpriteAppButtons = React.createClass({
+var SpriteAppButtons = createReactClass({
   displayName:'SpriteAppButtons',
   render: function() {
     return DisplayObjectContainer(
@@ -104,7 +105,7 @@ var SpriteAppButtons = React.createClass({
 // Component to display all the dynamic sprites
 //
 
-var DynamicSprites = React.createClass({
+var DynamicSprites = createReactClass({
   displayName:'DynamicSprites',
   propTypes: {
     sprites: React.PropTypes.arrayOf(React.PropTypes.object)
@@ -128,7 +129,7 @@ var DynamicSprites = React.createClass({
 // - x,y are the point to spin around
 // - spinspeed is the rotation speed in radians/sec
 // - spinme is a ReactElement to spin
-var SpinElement = React.createClass({
+var SpinElement = createReactClass({
   displayName: 'SpinElement',
   propTypes: {
     x: React.PropTypes.number.isRequired,
@@ -180,7 +181,7 @@ var SpinElement = React.createClass({
 // - sprites: a list of objects describing all the current sprites containing x,y and image fields
 //
 
-var SpriteApp = React.createClass({
+var SpriteApp = createReactClass({
   displayName: 'BunchOfSprites',
   render: function() {
     var halfwidth = this.props.width/2;

--- a/examples/jsxtransform/jsxtransform.jsx
+++ b/examples/jsxtransform/jsxtransform.jsx
@@ -6,6 +6,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 
 var assetpath = function(filename) { return '../assets/' + filename; };
 
@@ -20,7 +21,7 @@ var VectorText = ReactPIXI.Text;
 // - xposition: x position in pixels that governs where the elements are placed
 //
 
-var ExampleStage = React.createClass({
+var ExampleStage = createReactClass({
   displayName: 'ExampleStage',
   render: function() {
     var fontstyle = {font:'40px Times'};

--- a/examples/subclasssprite/spinningsprite.js
+++ b/examples/subclasssprite/spinningsprite.js
@@ -8,6 +8,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
+/* global createReactClass : false */
 
 var assetpath = function(filename) { return '../assets/' + filename; };
 
@@ -76,7 +77,7 @@ var SpinningSpriteComponent = ReactPIXI.CustomPIXIComponent({
 // - spinx,spiny,spinrotation : parameters passed to the spinning sprite
 //
 
-var SpinStage = React.createClass({
+var SpinStage = createReactClass({
   displayName: 'ExampleStage',
   render: function() {
     var child = React.createElement(SpinningSpriteComponent,

--- a/examples/viewpixeltests/viewpixeltests.js
+++ b/examples/viewpixeltests/viewpixeltests.js
@@ -11,6 +11,7 @@
 /* global React : false */
 /* global ReactPIXI : false */
 /* global pixelTests : false */
+/* global createReactClass : false */
 /* jshint strict: false */
 
 // the mounted instance will go here, so that callbacks can modify/set it
@@ -26,7 +27,7 @@ var g_applicationstate = {};
 // - sprites: a list of objects describing all the current sprites containing x,y and image fields
 //
 
-var PixelRefs = React.createClass({
+var PixelRefs = createReactClass({
   displayName: 'PixelRefs',
   render: function() {
     var testimageelements = _.map(this.props.testimageURLs, function(imageURL) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-preset-react": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
     "babel-runtime": "^6.6.1",
+    "create-react-class": "^15.6.0",
     "eslint": "^2.4.0",
     "expose-loader": "^0.7.0",
     "jasmine-core": "^2.4.1",

--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -25,6 +25,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 import * as PIXI from 'pixi.js';
 
 import ReactMultiChild from 'react-dom/lib/ReactMultiChild';
@@ -340,7 +341,7 @@ var DisplayObjectContainerMixin = assign({}, DisplayObjectMixin, ReactMultiChild
 // --GJH
 //
 
-var PIXIStage = React.createClass({
+var PIXIStage = createReactClass({
   displayName: 'PIXIStage',
   mixins: [DisplayObjectContainerMixin],
 

--- a/src/react-pixi-exposeglobals.js
+++ b/src/react-pixi-exposeglobals.js
@@ -4,6 +4,7 @@
 
 require('expose?React!react');
 require('expose?ReactDOM!react-dom');
+require('expose?createReactClass!create-react-class');
 //require('expose?PIXI!pixi.js');
 
 module.exports = require('./ReactPIXI.js');

--- a/test/components/composite.js
+++ b/test/components/composite.js
@@ -18,7 +18,7 @@ describe("PIXI Composite components", function() {
     // will update in-place and then updateComponent in ReactCompositeComponentMixin will try to nuke and replace the child
     // component since the keys don't match.
     //
-    var injectedKeyComponent = React.createClass({
+    var injectedKeyComponent = createReactClass({
       displayName: 'injectedKeyComponent',
       render: function () {
         var propswithkey = _.clone(this.props);
@@ -28,9 +28,9 @@ describe("PIXI Composite components", function() {
     });
     var injectedKeyFactory = React.createFactory(injectedKeyComponent);
 
-    // note we use React.createClass, not ReactPIXI.createClass, since the Stage
+    // note we use createReactClass, not ReactPIXI.createClass, since the Stage
     // is actually a <canvas> DOM element!
-    var injectedKeyStage = React.createClass({
+    var injectedKeyStage = createReactClass({
       displayName: 'injectedKeyStage',
       render: function () {
         return Stage({width:this.props.width, height:this.props.height, ref:'stage'},
@@ -82,7 +82,7 @@ describe("PIXI Composite components", function() {
     // thing to the parallel tree used by PIXI. But since the composite
     // itself itsn't part of PIXI scene graph this can get tricky.
     // see issue #7
-    var changedChildComponent = React.createClass({
+    var changedChildComponent = createReactClass({
       displayName:'changeChildComponent',
       render: function () {
         var compositechild = this.props.renderstate;
@@ -93,7 +93,7 @@ describe("PIXI Composite components", function() {
         }
       }
     });
-    var changedChildStageFactory = React.createFactory(React.createClass({
+    var changedChildStageFactory = React.createFactory(createReactClass({
       render: function() {
         return Stage({width:300,height:300,ref:'stage'},
           React.createElement(changedChildComponent, this.props));
@@ -121,7 +121,7 @@ describe("PIXI Composite components", function() {
     // we need to fall back on the default DOM behavior for nodes that are
     // not PIXI elements. So we'll do the same tests as above but with DOM nodes
 
-    var injectedKeyFactory = React.createFactory(React.createClass({
+    var injectedKeyFactory = React.createFactory(createReactClass({
       displayName: 'injectedKeyComponent',
       render : function() {
         var propswithkey = _.clone(this.props);
@@ -129,7 +129,7 @@ describe("PIXI Composite components", function() {
         return React.createElement('div', propswithkey);
       }
     }));
-    var injectedKeyStageFactory = React.createFactory(React.createClass({
+    var injectedKeyStageFactory = React.createFactory(createReactClass({
       displayName: 'injectedKeyStage',
       render: function () {
         return React.createElement('div', {ref:'rootnode'},

--- a/test/components/displayobjectcontainer.js
+++ b/test/components/displayobjectcontainer.js
@@ -11,7 +11,7 @@ describe("PIXI DisplayObject Component", function() {
   // has some specific number of DisplayObjectContainer objects as children.
   // you specify the number of children as props.childCount
   //
-  var VariableChildrenComponent = React.createClass({
+  var VariableChildrenComponent = createReactClass({
     displayName: 'variableChildrenComponent',
     render: function () {
       var docargs = [{key:'argh'}];

--- a/test/components/stage.js
+++ b/test/components/stage.js
@@ -42,7 +42,7 @@ describe("PIXI Stage Component", function() {
   it("passes the context down into pixi elements", function() {
 
     // this component is a sprite that uses the x/y from the context to position the sprite
-    var displayobjectfromcontext = React.createClass({
+    var displayobjectfromcontext = createReactClass({
       displayName:'DisplayObject_PositionFromContext',
       contextTypes: {
 	x_context: React.PropTypes.any,
@@ -58,7 +58,7 @@ describe("PIXI Stage Component", function() {
     });
     
     // this component creates a context that contains the desired sprite x/y position
-    var TestFixtureWithContext = React.createClass({
+    var TestFixtureWithContext = createReactClass({
       displayName:'TestFixtureWithContext',
       childContextTypes: {
 	x_context: React.PropTypes.any,

--- a/test/components/tilingsprite.js
+++ b/test/components/tilingsprite.js
@@ -8,7 +8,7 @@ describe("PIXI TilingSprite Component", () => {
   var Stage = React.createFactory(ReactPIXI.Stage);
   var TilingSprite = React.createFactory(ReactPIXI.TilingSprite);
 
-  var TilingSpriteTestComponent = React.createClass({
+  var TilingSpriteTestComponent = createReactClass({
     displayName: 'ExampleTilingSpriteComponent',
     render: function () {
       return Stage({width: width, height: height, ref: 'stage'},

--- a/test/createTestFixtureMountPoint.js
+++ b/test/createTestFixtureMountPoint.js
@@ -19,7 +19,7 @@
 // adding sub-objects to the BasicTestFixture component. This way we
 // avoid creating and destroying WebGL contexts, although you can
 // still it do 'by hand' by unmounting the component
-var BasicTestFixture = React.createClass({
+var BasicTestFixture = createReactClass({
   displayName: 'BasicTestFixture',
   render: function() {
     var stageprops = {width:this.props.width, height:this.props.height, ref:'stage'};

--- a/test/pixels/pixelTests.js
+++ b/test/pixels/pixelTests.js
@@ -7,7 +7,7 @@
 function drawTestRenders(mountpoint, testimages) {
   var halfanchor = new PIXI.Point(0.5,0.5);
 
-  var SpriteTestComponent = React.createClass({
+  var SpriteTestComponent = createReactClass({
     displayName:'SpriteTextComponent',
     render: function () {
       return React.createElement(ReactPIXI.Stage,


### PR DESCRIPTION
This project now depends on React@^15.6.1 and since 15.5.0 `React.createClass` was moved to `create-react-class` package. According to [React Without ES6 document](https://facebook.github.io/react/docs/react-without-es6.html), the `createReactClass` is a temporary drop-in replacement for `React.createClass`.

This PR removes the following React warning:
```
Warning: Accessing createClass via the main React package is deprecated, 
and will be removed in React v16.0. Use a plain JavaScript class instead. 
If you're not yet ready to migrate, create-react-class v15.* is available on npm 
as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
```