### PR TITLE
Replace React.PropTypes with PropTypes (since React 15.5)

### DIFF
--- a/examples/cupcake/cupcake.js
+++ b/examples/cupcake/cupcake.js
@@ -4,6 +4,7 @@
 
 /* jshint strict: false */
 /* global React : false */
+/* global PropTypes : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
 
@@ -35,8 +36,8 @@ var CupcakeComponent = React.createClass({
   },
 
   propTypes: {
-    xposition: React.PropTypes.number.isRequired,
-    topping: React.PropTypes.string.isRequired,
+    xposition: PropTypes.number.isRequired,
+    topping: PropTypes.string.isRequired,
   },
 
   render : function () {

--- a/examples/filters/filters.js
+++ b/examples/filters/filters.js
@@ -4,6 +4,7 @@
 
 /* jshint strict: false */
 /* global React : false */
+/* global PropTypes : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
 
@@ -34,8 +35,8 @@ var CupcakeComponent = React.createClass({
     'pink' : assetpath('creamPink.png'),
   },
   propTypes: {
-    xposition: React.PropTypes.number.isRequired,
-    topping: React.PropTypes.string.isRequired,
+    xposition: PropTypes.number.isRequired,
+    topping: PropTypes.string.isRequired,
   },
 
   render : function () {
@@ -67,9 +68,9 @@ var BlurredCupcakeComponent = React.createClass({
   },
 
   propTypes: {
-    xposition: React.PropTypes.number.isRequired,
-    topping: React.PropTypes.string.isRequired,
-    bluramount: React.PropTypes.number.isRequired
+    xposition: PropTypes.number.isRequired,
+    topping: PropTypes.string.isRequired,
+    bluramount: PropTypes.number.isRequired
   },
 
   render : function() {

--- a/examples/interactive/interactive.js
+++ b/examples/interactive/interactive.js
@@ -9,6 +9,7 @@
 // tell jshint that we use lodash
 /* global _ : false */
 /* global React : false */
+/* global PropTypes : false */
 /* global ReactPIXI : false */
 /* global PIXI : false */
 /* jshint strict: false */
@@ -107,7 +108,7 @@ var SpriteAppButtons = React.createClass({
 var DynamicSprites = React.createClass({
   displayName:'DynamicSprites',
   propTypes: {
-    sprites: React.PropTypes.arrayOf(React.PropTypes.object)
+    sprites: PropTypes.arrayOf(PropTypes.object)
   },
   render: function() {
     var args = [{}];
@@ -131,10 +132,10 @@ var DynamicSprites = React.createClass({
 var SpinElement = React.createClass({
   displayName: 'SpinElement',
   propTypes: {
-    x: React.PropTypes.number.isRequired,
-    y: React.PropTypes.number.isRequired,
-    spinspeed: React.PropTypes.number.isRequired,
-    spinme: React.PropTypes.object.isRequired
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    spinspeed: PropTypes.number.isRequired,
+    spinme: PropTypes.object.isRequired
   },
 
   getInitialState: function() {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lodash": "^4.6.1",
     "node-static": "~0.7.3",
     "pixi.js": "^4.5.0",
+    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "resemblejs": "~2.2.0",

--- a/src/react-pixi-exposeglobals.js
+++ b/src/react-pixi-exposeglobals.js
@@ -4,6 +4,7 @@
 
 require('expose?React!react');
 require('expose?ReactDOM!react-dom');
+require('expose?PropTypes!prop-types');
 //require('expose?PIXI!pixi.js');
 
 module.exports = require('./ReactPIXI.js');

--- a/test/components/stage.js
+++ b/test/components/stage.js
@@ -45,8 +45,8 @@ describe("PIXI Stage Component", function() {
     var displayobjectfromcontext = React.createClass({
       displayName:'DisplayObject_PositionFromContext',
       contextTypes: {
-	x_context: React.PropTypes.any,
-	y_context: React.PropTypes.any
+	x_context: PropTypes.any,
+	y_context: PropTypes.any
       },
       render: function() {
 	console.log(this.context);
@@ -61,8 +61,8 @@ describe("PIXI Stage Component", function() {
     var TestFixtureWithContext = React.createClass({
       displayName:'TestFixtureWithContext',
       childContextTypes: {
-	x_context: React.PropTypes.any,
-	y_context: React.PropTypes.any
+	x_context: PropTypes.any,
+	y_context: PropTypes.any
       },
       getChildContext: function() {
 	return {


### PR DESCRIPTION
This project now depends on React@^15.6.1 and since 15.5.0 `React.PropTypes` was moved to `prop-types` package.

This PR removes the following React warning:
```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs'
```