### PR TITLE
Made the "renderStage" on Stage update optional

### DIFF
--- a/src/ReactPIXI.js
+++ b/src/ReactPIXI.js
@@ -519,7 +519,9 @@ var PIXIStage = createReactClass({
     );
     ReactUpdates.ReactReconcileTransaction.release(transaction);
 
-    this.renderStage();
+    if (!newProps.skipUpdateRender) {
+      this.renderStage();
+    }
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
Made the "renderStage" on Stage update optional by listening to the props the "skipUpdateRender".

https://github.com/Izzimach/react-pixi/issues/111